### PR TITLE
fix: GET request /mcp

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,7 @@
 [build]
 publish = "public"
+
+[[redirects]]
+from = "/mcp"
+to = "/"
+status = 302

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,5 @@ publish = "public"
 
 [[redirects]]
 from = "/mcp"
-to = "/"
-status = 302
+to = "https://docs.astro.build/en/guides/build-with-ai/"
+status = 303

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,5 @@ publish = "public"
 
 [[redirects]]
 from = "/mcp"
-to = "https://docs.astro.build/en/guides/build-with-ai/"
+to = "/"
 status = 303


### PR DESCRIPTION
People (myself included) expect to see something when calling https://mcp.docs.astro.build/mcp in their browser (which is a GET request) because they initially do not understand that a MCP server works with POST requests.

I therefore added a redirect rule which redirects all HTTP methods to the Astro docs with status 303 ("See other"). But because Netlify edge functions [take precedence](https://docs.netlify.com/manage/routing/redirects/overview/#rule-processing-order) over redirects, the  MCP Server with HTTP method POST still works unaffected 🙌