### PR TITLE
Return "Method Not Allowed" and Do Not Allow MCP Requests to "/"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,2 @@
 [build]
 publish = "public"
-
-[[redirects]]
-from = "/mcp"
-to = "/"
-status = 303

--- a/netlify/edge-functions/mcp-server.ts
+++ b/netlify/edge-functions/mcp-server.ts
@@ -96,6 +96,15 @@ function formatResponse(data: unknown): {
 
 // Netlify Edge Function Handler
 export default async function handler(req: Request) {
+  if (req.method === "GET") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: {
+        "Content-Type": "text/plain",
+        Allow: "POST",
+      },
+    });
+  }
   try {
     const { req: nodeReq, res: nodeRes } = toReqRes(req);
     const server = getServer();
@@ -128,6 +137,6 @@ export default async function handler(req: Request) {
 }
 
 export const config: Config = {
-  path: ["/mcp", "/"],
-  method: ["POST"],
+  path: ["/mcp"],
+  method: ["POST", "GET"],
 };


### PR DESCRIPTION
#### Description

Return `"Method Not Allowed" (405)` HTTP status code if editor requests `GET https://mcp.docs.astro.build/mcp` to indicate that SSE is not supported by this MCP server. Currently redirects to `/` as you can try out by clicking on the link. [See the specification for details](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server)

**⚠️ Potential breaking change: 🚧** If user has their URL config without `/mcp` (which is not allowed according to all documentation from Astro MCP server I found -> wrong config), MCP server will not respond anymore. I'm not sure why the edge function even runs on the `/` path, but I removed it since the `index.html` is served under that route.

- Closes #4 
- Reverts #1 